### PR TITLE
Add "use client" directive

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["playground", "website"]
+  "ignore": ["playground"]
 }

--- a/.changeset/popular-moles-punch.md
+++ b/.changeset/popular-moles-punch.md
@@ -1,0 +1,5 @@
+---
+"react-awesome-reveal": minor
+---
+
+Add RSC frameworks support

--- a/packages/lib/src/Reveal.tsx
+++ b/packages/lib/src/Reveal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ClassNames } from "@emotion/react";
 import type { Keyframes, SerializedStyles } from "@emotion/serialize";
 import { Children, type CSSProperties, isValidElement, useMemo } from "react";

--- a/packages/lib/src/components/AttentionSeeker.tsx
+++ b/packages/lib/src/components/AttentionSeeker.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Keyframes } from "@emotion/serialize";
 import { type CSSProperties, useMemo } from "react";
 

--- a/packages/lib/src/components/Bounce.tsx
+++ b/packages/lib/src/components/Bounce.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 import {

--- a/packages/lib/src/components/Fade.tsx
+++ b/packages/lib/src/components/Fade.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 import {

--- a/packages/lib/src/components/Flip.tsx
+++ b/packages/lib/src/components/Flip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type CSSProperties, useMemo } from "react";
 
 import {

--- a/packages/lib/src/components/Hinge.tsx
+++ b/packages/lib/src/components/Hinge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { CSSProperties } from "react";
 
 import { hinge } from "../animations/specials";

--- a/packages/lib/src/components/JackInTheBox.tsx
+++ b/packages/lib/src/components/JackInTheBox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { jackInTheBox } from "../animations/specials";
 import { Reveal, type RevealProps } from "../Reveal";
 

--- a/packages/lib/src/components/Roll.tsx
+++ b/packages/lib/src/components/Roll.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 import { rollIn, rollOut } from "../animations/specials";

--- a/packages/lib/src/components/Rotate.tsx
+++ b/packages/lib/src/components/Rotate.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Keyframes } from "@emotion/serialize";
 import { type CSSProperties, useMemo } from "react";
 

--- a/packages/lib/src/components/Slide.tsx
+++ b/packages/lib/src/components/Slide.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 import {

--- a/packages/lib/src/components/Zoom.tsx
+++ b/packages/lib/src/components/Zoom.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 import {


### PR DESCRIPTION
Adds the `"use client"` directive to all animated components, in order to work with RSC frameworks like Next.js

Closes #201 